### PR TITLE
Fix read_one_msg() remove last line from "Response:" lines

### DIFF
--- a/src/phpagi-asmanager.php
+++ b/src/phpagi-asmanager.php
@@ -192,7 +192,11 @@
       $type = strtolower($r[0]);
 
       if ($r[1] == 'Success' || $r[1] == 'Follows') {
-          $m = explode(': ', $msgarr[2]);
+          if (array_key_exists(2, $msgarr)) {
+              $m = explode(': ', $msgarr[2]);
+          } else {
+              $m[1] = 'Ignore me';
+          }
           $msgarr_tmp = $msgarr;
           $str = array_pop($msgarr);
           $lastline = strpos($str, '--END COMMAND--');

--- a/src/phpagi-asmanager.php
+++ b/src/phpagi-asmanager.php
@@ -198,7 +198,7 @@
               $m[1] = 'Ignore me';
           }
           $msgarr_tmp = $msgarr;
-          $str = array_pop($msgarr);
+          $str = array_slice($msgarr, -1)[0];
           $lastline = strpos($str, '--END COMMAND--');
           if (false !== $lastline) {
               $parameters['data'] = substr($str, 0, $lastline-1); // cut '\n' too


### PR DESCRIPTION
`AGI_AsteriskManager::send_request('StopMixMonitor')` cannot back to program.
Cause infinity loop bug at read_one_msg().

```PHP
$channel = 'Some Asterisk channel';
$asmanager->send_request( 'StopMixMonitor', array('Channel' => $channel) );
// Cannot reach here
```

Response from some AMI action (example: "StopMixMonitor") only 2 lines.

```text
Response: Success
ActionID: A41854362
```

`array_pop()` in `read_one_msg()` remove last line("ActionID:") of responses
from Asterisk.  And `wait_response()` call from `send_request()`
waiting "ActionID:" EVER.


NOTE:
This commit change value of 'Output' key in response of `Command()`

```PHP
<?php
//require_once 'src/phpagi-asmanager.php.orig';
require_once 'src/phpagi-asmanager.php';

$asmanager = new AGI_Asteriskmanager();
$asmanager->connect('localhost', 'sampleuser', 'fake_password');

// Command output sample:
/*
Channel                                                          Location                         State   Application(Data)
0 active channels
0 active calls
92 calls processed
*/
$response = $asmanager->Command('core show channels');

// Same output:
print("Response:{$response['Response']}\n"); // Success
print("Message:{$response['Message']}\n"); // "Command output follows"
print("Command output:\n{$response['data']}\n");

// Different output:
// before: last-1 line of command output: "0 active calls"
// after:  last   line of command output: "92 calls processed"
print("Output key: {$response['Output']}\n");

// ActionID different every time
print("ActionID:{$response['ActionID']}\n");
```

I tested with:
PHP: 5.4.16 and 8.4.4 (Note: Can't use `array_key_last()` with PHP < 7.3.0)
Asterisk: 20.12.0
